### PR TITLE
chore: Update organisation links to growilabs

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2017 WESEEK, Inc.
+Copyright (c) 2017 GROWI, Inc.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 growi-docker-compose
 =====================
 
-Quick start [GROWI](https://github.com/weseek/growi) with docker-compose
+Quick start [GROWI](https://github.com/growilabs/growi) with docker-compose
 
 ![GROWI-x-dockercompose](https://user-images.githubusercontent.com/1638767/38307565-105956e2-384f-11e8-8534-b1128522d68d.png)
 
@@ -23,7 +23,7 @@ Start
 ------
 
 ```bash
-git clone https://github.com/weseek/growi-docker-compose.git growi
+git clone https://github.com/growilabs/growi-docker-compose.git growi
 cd growi
 docker-compose up
 ```
@@ -111,15 +111,15 @@ Followings are **disabled** because they are overwritten by `docker-compose.yml`
 
 Change `docker-compose.yml` if you need.
 
-Others conform to [weseek/growi](https://github.com/weseek/growi#environment-variables)
+Others conform to [weseek/growi](https://github.com/growilabs/growi#environment-variables)
 
 
 More convenient Examples
 -------------------------
 
-* [Multiple sites](https://github.com/weseek/growi-docker-compose/tree/master/examples/multi-app)
-* [HTTPS(with Let's Encrypt) proxy integration](https://github.com/weseek/growi-docker-compose/tree/master/examples/https-portal)
-* [Backup MongoDB data](https://github.com/weseek/growi-docker-compose/tree/master/examples/backup-mongodb-data)
+* [Multiple sites](https://github.com/growilabs/growi-docker-compose/tree/master/examples/multi-app)
+* [HTTPS(with Let's Encrypt) proxy integration](https://github.com/growilabs/growi-docker-compose/tree/master/examples/https-portal)
+* [Backup MongoDB data](https://github.com/growilabs/growi-docker-compose/tree/master/examples/backup-mongodb-data)
 
 
 Documentation
@@ -131,7 +131,7 @@ Documentation
 Issues
 ------
 
-If you have any problems or questions about this image, please contact us through a [GitHub issue](https://github.com/weseek/growi-docker-compose/issues).
+If you have any problems or questions about this image, please contact us through a [GitHub issue](https://github.com/growilabs/growi-docker-compose/issues).
 
 
 License

--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ Followings are **disabled** because they are overwritten by `docker-compose.yml`
 
 Change `docker-compose.yml` if you need.
 
-Others conform to [weseek/growi](https://github.com/growilabs/growi#environment-variables)
+Others conform to [growilabs/growi](https://github.com/growilabs/growi#environment-variables)
 
 
 More convenient Examples

--- a/examples/backup-mongodb-data/README.md
+++ b/examples/backup-mongodb-data/README.md
@@ -18,7 +18,7 @@ Requirements
 
 0. Clone repos
     ```
-    git clone https://github.com/weseek/growi-docker-compose.git growi
+    git clone https://github.com/growilabs/growi-docker-compose.git growi
     cd growi
     ```
 1. Copy `docker-compose.override.yml` to local repos root

--- a/examples/growi-unique-ogp/README.md
+++ b/examples/growi-unique-ogp/README.md
@@ -10,7 +10,7 @@ Install and Start
 ### Clone repos and copy docker-compose.override.yml
 
 ```bash
-git clone https://github.com/weseek/growi-docker-compose.git growi
+git clone https://github.com/growilabs/growi-docker-compose.git growi
 cd growi
 cp examples/growi-unique-ogp/docker-compose.override.yml .
 ```

--- a/examples/https-portal/README.md
+++ b/examples/https-portal/README.md
@@ -9,7 +9,7 @@ Install and Start
 ### Clone repos and copy docker-compose.override.yml
 
 ```bash
-git clone https://github.com/weseek/growi-docker-compose.git growi
+git clone https://github.com/growilabs/growi-docker-compose.git growi
 cd growi
 cp examples/https-portal/docker-compose.override.yml .
 ```

--- a/examples/multi-app/README.md
+++ b/examples/multi-app/README.md
@@ -9,7 +9,7 @@ Install and Start
 ### Build Image
 
 ```bash
-git clone https://github.com/weseek/growi-docker-compose.git growi
+git clone https://github.com/growilabs/growi-docker-compose.git growi
 cd growi
 docker build -t growimulti_app .
 ```


### PR DESCRIPTION
## Task
- [#170911](https://redmine.weseek.co.jp/issues/170911) GROWI 関連リポジトリを全て growilabs に移行する
  - [#171190](https://redmine.weseek.co.jp/issues/171190) [growilabs/growi-docker-compose] 旧 org のリンクを新 org のリンクに置き換える